### PR TITLE
Update ignore file and pull code for gromacs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .pyc
 .swp
 .ipynb_checkpoints
+.ipynb_checkpoints/
 __pycache__

--- a/workflow/util/mdp_files/compress.mdp
+++ b/workflow/util/mdp_files/compress.mdp
@@ -44,6 +44,7 @@ pull-print-components  = yes
 
 pull-coord1-type      = constant-force
 pull-coord1-geometry  = direction-periodic
+pull-coord1-dim	      = N N Y
 pull-coord1-vec       = 0.0 0.0 -1.0
 pull-coord1-groups    = 2 1
 pull-coord1-k         = 3125

--- a/workflow/util/mdp_files/shear_15nN-rerun.mdp
+++ b/workflow/util/mdp_files/shear_15nN-rerun.mdp
@@ -47,6 +47,7 @@ pull-print-components  = yes
 
 pull-coord1-type      = umbrella
 pull-coord1-geometry  = direction-periodic
+pull-coord1-dim	      = Y N N
 pull-coord1-vec       = 1.0 0.0 0.0 ; shear force direction vector
 pull-coord1-groups    = 0 2
 pull-coord1-rate      = 0.01 ; nm/ps
@@ -55,6 +56,7 @@ pull-coord1-start     = yes
 
 pull-coord2-type      = constant-force
 pull-coord2-geometry  = direction-periodic
+pull-coord2-dim       = N N Y
 pull-coord2-vec       = 0.0 0.0 -1.0 ; normal force vector
 pull-coord2-groups    = 2 1
 pull-coord2-k         = 9375  ; normal force

--- a/workflow/util/mdp_files/shear_15nN.mdp
+++ b/workflow/util/mdp_files/shear_15nN.mdp
@@ -47,6 +47,7 @@ pull-print-components  = yes
 
 pull-coord1-type      = umbrella
 pull-coord1-geometry  = direction-periodic
+pull-coord1-dim	      = Y N N
 pull-coord1-vec       = 1.0 0.0 0.0 ; shear force direction vector
 pull-coord1-groups    = 0 2
 pull-coord1-rate      = 0.01 ; nm/ps
@@ -55,6 +56,7 @@ pull-coord1-start     = yes
 
 pull-coord2-type      = constant-force
 pull-coord2-geometry  = direction-periodic
+pull-coord2-dim       = N N Y
 pull-coord2-vec       = 0.0 0.0 -1.0 ; normal force vector
 pull-coord2-groups    = 2 1
 pull-coord2-k         = 9375  ; normal force

--- a/workflow/util/mdp_files/shear_25nN-rerun.mdp
+++ b/workflow/util/mdp_files/shear_25nN-rerun.mdp
@@ -47,6 +47,7 @@ pull-print-components  = yes
 
 pull-coord1-type      = umbrella
 pull-coord1-geometry  = direction-periodic
+pull-coord1-dim       = Y N N
 pull-coord1-vec       = 1.0 0.0 0.0 ; shear force direction vector
 pull-coord1-groups    = 0 2
 pull-coord1-rate      = 0.01 ; nm/ps
@@ -55,6 +56,7 @@ pull-coord1-start     = yes
 
 pull-coord2-type      = constant-force
 pull-coord2-geometry  = direction-periodic
+pull-coord2-dim       = N N Y
 pull-coord2-vec       = 0.0 0.0 -1.0 ; normal force vector
 pull-coord2-groups    = 2 1
 pull-coord2-k         = 15625  ; normal force

--- a/workflow/util/mdp_files/shear_25nN.mdp
+++ b/workflow/util/mdp_files/shear_25nN.mdp
@@ -47,6 +47,7 @@ pull-print-components  = yes
 
 pull-coord1-type      = umbrella
 pull-coord1-geometry  = direction-periodic
+pull-coord1-dim       = Y N N
 pull-coord1-vec       = 1.0 0.0 0.0 ; shear force direction vector
 pull-coord1-groups    = 0 2
 pull-coord1-rate      = 0.01 ; nm/ps
@@ -55,6 +56,7 @@ pull-coord1-start     = yes
 
 pull-coord2-type      = constant-force
 pull-coord2-geometry  = direction-periodic
+pull-coord2-dim       = N N Y
 pull-coord2-vec       = 0.0 0.0 -1.0 ; normal force vector
 pull-coord2-groups    = 2 1
 pull-coord2-k         = 15625  ; normal force

--- a/workflow/util/mdp_files/shear_5nN-rerun.mdp
+++ b/workflow/util/mdp_files/shear_5nN-rerun.mdp
@@ -47,6 +47,7 @@ pull-print-components  = yes
 
 pull-coord1-type      = umbrella
 pull-coord1-geometry  = direction-periodic
+pull-coord1-dim       = Y N N
 pull-coord1-vec       = 1.0 0.0 0.0 ; shear force direction vector
 pull-coord1-groups    = 0 2
 pull-coord1-rate      = 0.01 ; nm/ps
@@ -55,6 +56,7 @@ pull-coord1-start     = yes
 
 pull-coord2-type      = constant-force
 pull-coord2-geometry  = direction-periodic
+pull-coord2-dim       = N N Y
 pull-coord2-vec       = 0.0 0.0 -1.0 ; normal force vector
 pull-coord2-groups    = 2 1
 pull-coord2-k         = 3125  ; normal force

--- a/workflow/util/mdp_files/shear_5nN.mdp
+++ b/workflow/util/mdp_files/shear_5nN.mdp
@@ -47,6 +47,7 @@ pull-print-components  = yes
 
 pull-coord1-type      = umbrella
 pull-coord1-geometry  = direction-periodic
+pull-coord1-dim       = Y N N
 pull-coord1-vec       = 1.0 0.0 0.0 ; shear force direction vector
 pull-coord1-groups    = 0 2
 pull-coord1-rate      = 0.01 ; nm/ps
@@ -55,6 +56,7 @@ pull-coord1-start     = yes
 
 pull-coord2-type      = constant-force
 pull-coord2-geometry  = direction-periodic
+pull-coord2-dim       = N N Y
 pull-coord2-vec       = 0.0 0.0 -1.0 ; normal force vector
 pull-coord2-groups    = 2 1
 pull-coord2-k         = 3125  ; normal force


### PR DESCRIPTION
Newer versions of Gromacs (2018-> present) are a bit more stringent with
their enforcement of box dimensions when using the pull code.

However, after viewing [this git
issue](https://redmine.gromacs.org/issues/1962#note-5) it appears that
defining more explicitly the dimensions of the pull vector appears to
relax the box dimension warnings.